### PR TITLE
Added customization for some Telescope menu keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,9 @@ require('leetbuddy').setup({
     domain = "com"  -- `cn` for chinese leetcode
     language = "py",
     keys = {
-        -- Overwrites the key to select the question
-        select = "<Space>",
-        -- These replace Alt with Ctrl
+        select = "<CR>",
         reset = "<C-r>",
         easy = "<C-e>",
-        -- Can't use <C-m> since that is interpreted as <CR>
         medium = "<C-d>",
         hard = "<C-h>",
         accepted = "<C-a>",

--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ LeetBuddy.nvim provides the following commands:
 
 - `LBQuestions`: Lists all Leetcode problems with submission status and difficulty level.
   Additionally, there are custom filters available to further refine the displayed problems:
-  - `<A-r>`: Reset all filters and display all problems.
-  - `<A-e>`: Display only easy difficulty problems.
-  - `<A-m>`: Display only medium difficulty problems.
-  - `<A-h>`: Display only hard difficulty problems.
-  - `<A-a>`: Display only problems with a status of "Accepted" (AC).
-  - `<A-y>`: Display only problems with a status of "Not Started" (NOT_STARTED).
-  - `<A-t>`: Display only problems with a status of "Tried" (TRIED).
+  - `<C-r>`: Reset all filters and display all problems.
+  - `<C-e>`: Display only easy difficulty problems.
+  - `<C-d>`: Display only medium difficulty problems.
+  - `<C-h>`: Display only hard difficulty problems.
+  - `<C-a>`: Display only problems with a status of "Accepted" (AC).
+  - `<C-y>`: Display only problems with a status of "Not Started" (NOT_STARTED).
+  - `<C-t>`: Display only problems with a status of "Tried" (TRIED).
 - `LBQuestion`: Displays the question in a popup window.
 - `LBReset`: Resets the code of the current question to the default template.
 - `LBTest`: Runs the test cases for the current question. Multiple test cases can be added.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ require('leetbuddy').setup({
         -- These replace Alt with Ctrl
         reset = "<C-r>",
         easy = "<C-e>",
-        medium = "<C-m>",
+        -- Can't use <C-m> since that is interpreted as <CR>
+        medium = "<C-d>",
         hard = "<C-h>",
         accepted = "<C-a>",
         not_started = "<C-y>",

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # LeetBuddy.nvim
 
+**Forked from Dhanus3133/Leetbuddy.nvim to add the ability to change keybindings in the LBQuestions picker**
+
 LeetBuddy.nvim enables seamless integration with **Leetcode**, empowering you to solve coding problems effortlessly within Neovim.
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # LeetBuddy.nvim
 
-**Forked from Dhanus3133/Leetbuddy.nvim to add the ability to change keybindings in the LBQuestions picker**
-
 LeetBuddy.nvim enables seamless integration with **Leetcode**, empowering you to solve coding problems effortlessly within Neovim.
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ LeetBuddy.nvim allows you to customize certain aspects of its behavior. You can 
 require('leetbuddy').setup({
     domain = "com"  -- `cn` for chinese leetcode
     language = "py",
+    keys = {
+        -- Overwrites the key to select the question
+        select = "<Space>",
+        -- These replace Alt with Ctrl
+        reset = "<C-r>",
+        easy = "<C-e>",
+        medium = "<C-m>",
+        hard = "<C-h>",
+        accepted = "<C-a>",
+        not_started = "<C-y>",
+        tried = "<C-t>",
+    }
 })
 ```
 

--- a/lua/leetbuddy/default_config.lua
+++ b/lua/leetbuddy/default_config.lua
@@ -7,13 +7,13 @@ local default_config = {
   debug = false,
   keys = {
     select = "<CR>",
-    reset = "<A-r>",
-    easy = "<A-e>",
-    medium = "<A-m>",
-    hard = "<A-h>",
-    accepted = "<A-a>",
-    not_started = "<A-y>",
-    tried = "<A-t>",
+    reset = "<C-r>",
+    easy = "<C-e>",
+    medium = "<C-m>",
+    hard = "<C-h>",
+    accepted = "<C-a>",
+    not_started = "<C-y>",
+    tried = "<C-t>",
   },
 }
 

--- a/lua/leetbuddy/default_config.lua
+++ b/lua/leetbuddy/default_config.lua
@@ -5,6 +5,16 @@ local default_config = {
   directory = vim.loop.os_homedir() .. sep .. ".leetcode",
   language = "py",
   debug = false,
+  keys = {
+    select = "<CR>",
+    reset = "<A-r>",
+    easy = "<A-e>",
+    medium = "<A-m>",
+    hard = "<A-h>",
+    accepted = "<A-a>",
+    not_started = "<A-y>",
+    tried = "<A-t>",
+  },
 }
 
 return default_config

--- a/lua/leetbuddy/questions.lua
+++ b/lua/leetbuddy/questions.lua
@@ -174,33 +174,33 @@ function M.questions()
       }),
       sorter = conf.generic_sorter(opts),
       attach_mappings = function(_, map)
-        map({ "n", "i" }, "<CR>", select_problem)
-        map({ "n", "i" }, "<A-r>", function()
+        map({ "n", "i" }, config.keys.select, select_problem)
+        map({ "n", "i" }, config.keys.reset, function()
           M.difficulty = nil
           M.status = nil
           M.questions()
         end)
-        map({ "n", "i" }, "<A-e>", function()
+        map({ "n", "i" }, config.keys.easy, function()
           M.difficulty = "EASY"
           M.questions()
         end)
-        map({ "n", "i" }, "<A-m>", function()
+        map({ "n", "i" }, config.keys.medium, function()
           M.difficulty = "MEDIUM"
           M.questions()
         end)
-        map({ "n", "i" }, "<A-h>", function()
+        map({ "n", "i" }, config.keys.hard, function()
           M.difficulty = "HARD"
           M.questions()
         end)
-        map({ "n", "i" }, "<A-a>", function()
+        map({ "n", "i" }, config.keys.accepted, function()
           M.status = "AC"
           M.questions()
         end)
-        map({ "n", "i" }, "<A-y>", function()
+        map({ "n", "i" }, config.keys.not_started, function()
           M.status = "NOT_STARTED"
           M.questions()
         end)
-        map({ "n", "i" }, "<A-t>", function()
+        map({ "n", "i" }, config.keys.tried, function()
           M.status = "TRIED"
           M.questions()
         end)

--- a/lua/leetbuddy/reset.lua
+++ b/lua/leetbuddy/reset.lua
@@ -23,6 +23,7 @@ function M.reset_question()
     local query = [[
       query questionData($titleSlug: String!) {
         question(titleSlug: $titleSlug) {
+          exampleTestcaseList
           sampleTestCase
           codeSnippets {
             langSlug
@@ -56,7 +57,11 @@ function M.reset_question()
     local input_file = io.open(input, "w")
 
     if input_file then
-      input_file:write(question["sampleTestCase"])
+      for _, testcase in ipairs(question["exampleTestcaseList"]) do
+         print(testcase)
+         input_file:write(testcase .. "\n")
+      end
+      -- input_file:write(question["sampleTestCase"])
       input_file:close()
     else
       print("Failed to open the file.")

--- a/lua/leetbuddy/reset.lua
+++ b/lua/leetbuddy/reset.lua
@@ -58,7 +58,6 @@ function M.reset_question()
 
     if input_file then
       for _, testcase in ipairs(question["exampleTestcaseList"]) do
-         print(testcase)
          input_file:write(testcase .. "\n")
       end
       -- input_file:write(question["sampleTestCase"])


### PR DESCRIPTION
User can now customize the keys set by LeetBuddy to navigate the Telescope menu. Alt keys are sometimes frustrating to use since many terminals and GUIs use Alt keys and don't send them to applications. This pull request allows users to easily specify alternate keybinds in the setup of LeetBuddy. Defaults remain the same, though I was unable to test any of them except for <CR> and <A-y> due to my setup. 